### PR TITLE
Pre-update pkgs to avoid Travis dependency error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - make
   - sudo make install
   - cd /home/travis/build/ropensci/hddtools
+  - Rscript -e 'update.packages(ask = FALSE)' 
 
 r_github_packages:
   - jimhester/covr


### PR DESCRIPTION
The Travis failure appears to be a known issue that should be transient due to Ubuntu package update schedules.  It is described with this workaround here: https://github.com/travis-ci/travis-ci/issues/6850